### PR TITLE
[#127] FIX: 매물 빌드 오류 수정

### DIFF
--- a/src/components/article/ArticlePrice.tsx
+++ b/src/components/article/ArticlePrice.tsx
@@ -3,8 +3,8 @@ import { formatPrice, isZeroPrice } from '../../utils/articleUtils';
 
 interface ArticlePriceProps {
     tradeType: string;
-    priceSale: string | number | null;
-    priceRent?: number;
+    priceSale: number;
+    priceRent: number;
     priceRoomMin?: number;
     priceRoomMax?: number;
 }

--- a/src/types/article.ts
+++ b/src/types/article.ts
@@ -51,6 +51,12 @@ export interface ArticleResponse {
     address2SiGunGu: string;
     address3DongEupMyeon: string;
     complexId?: number;
+    articleType: string;
+    cortarName?: string;
+    buildingName?: string;
+    district?: string;
+    town?: string;
+    atclFetrDesc?: string;
 }
 
 export interface ComplexResponse {


### PR DESCRIPTION
## 💡 개요
ArticlePrice.tsx 에서 Argument of type 'string | number' is not assignable to parameter of type 'number'. 오류 수정하고 articles.ts 에서 type 지정으로 빌드 오류 수정하였습니다.

Resolves: #127

## 🔧 PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 배포 및 PR 관련

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
